### PR TITLE
Add additional annotations

### DIFF
--- a/HomepageSC/AnnotationKey.cs
+++ b/HomepageSC/AnnotationKey.cs
@@ -6,6 +6,8 @@ public static class AnnotationKey
     public const string Group = "homepagesc.neutrino.io/group";
     public const string WidgetType = "homepagesc.neutrino.io/widget_type";
     public const string WidgetSecret = "homepagesc.neutrino.io/widget_secret";
+    public const string WidgetUrl = "homepagesc.neutrino.io/widget_url";
+    public const string WidgetUsernamePasswordSecret = "homepagesc.neutrino.io/widget_username_password_secret";
     public const string Target = "homepagesc.neutrino.io/target";
     public const string Description = "homepagesc.neutrino.io/description";
     public const string Icon = "homepagesc.neutrino.io/icon";

--- a/HomepageSC/Widget.cs
+++ b/HomepageSC/Widget.cs
@@ -2,14 +2,18 @@ namespace HomepageSC;
 
 public class Widget
 {
-    public Widget(string type, string url, string? key)
+    public Widget(string type, string url, string? key, string? username, string? password)
     {
         Type = type;
         Url = url;
         Key = key;
+        Username = username;
+        Password = password;
     }
 
     public string Type { get; }
     public string Url { get; }
     public string? Key { get; }
+    public string? Username { get; }
+    public string? Password { get; }
 }


### PR DESCRIPTION
In some cases you might want to specify a different widget URL (like in the case for prometheus, you want the ingress to link to grafana, but you want the api to link to the metrics pod).

And in some cases you want to specify a username/password for auth as opposed to a secret in the `key` field.

This PR adds both of these additional annotations so that they can be specified if required.